### PR TITLE
Ajout d'un DemoController avec une route /demo et son template associé

### DIFF
--- a/src/Controller/DemoController.php
+++ b/src/Controller/DemoController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class DemoController extends AbstractController
+{
+    #[Route('/demo', name: 'app_demo')]
+    public function index(): Response
+    {
+        return $this->render('demo/index.html.twig', [
+            'controller_name' => 'DemoController',
+        ]);
+    }
+}

--- a/templates/demo/index.html.twig
+++ b/templates/demo/index.html.twig
@@ -1,0 +1,20 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Hello DemoController!{% endblock %}
+
+{% block body %}
+<style>
+    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
+    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
+</style>
+
+<div class="example-wrapper">
+    <h1>Hello {{ controller_name }}! ✅</h1>
+
+    This friendly message is coming from:
+    <ul>
+        <li>Your controller at <code>/Applications/MAMP/htdocs/la-boutique-S7/src/Controller/DemoController.php</code></li>
+        <li>Your template at <code>/Applications/MAMP/htdocs/la-boutique-S7/templates/demo/index.html.twig</code></li>
+    </ul>
+</div>
+{% endblock %}


### PR DESCRIPTION
Cette Pull Request ajoute un nouveau controller Symfony nommé DemoController, qui définit une route '/demo'. Ce controller retourne une vue Twig simple affichant un message de bienvenue personnalisé. Le template associé 'demo/index.html.twig' étend la base et présente une page avec un message indiquant l'emplacement du controller et du template. Cette PR sert à démo ou à test et met en place une structure basique pour étendre la fonctionnalité de l'application.